### PR TITLE
Add Scala 3 Support for sbt-scalate-precompiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This plugin is published to sonatype oss repository.
 Include the plugin in `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("org.scalatra.scalate" % "sbt-scalate-precompiler" % "1.9.6.0")
+addSbtPlugin("org.scalatra.scalate" % "sbt-scalate-precompiler" % "1.10.0.0")
 ```
 
 Configure the plugin in `build.sbt`:

--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,13 @@ lazy val precompiler = (project in file("precompiler")).settings(baseSettings).s
   sbtPlugin := false,
   name := "scalate-precompiler",
   libraryDependencies += "org.scalatra.scalate" %% "scalate-core" % "1.10.1" % "compile",
-  crossScalaVersions := Seq("2.13.14", "2.12.20", "2.11.12")
+  crossScalaVersions := Seq("3.3.3", "2.13.14", "2.12.20", "2.11.12")
 ).disablePlugins(ScriptedPlugin)
 
 lazy val plugin = (project in file("plugin")).settings(baseSettings).settings(
   name := "sbt-scalate-precompiler",
   sbtPlugin := true,
-  crossSbtVersions := Seq("1.3.10"),
+  crossSbtVersions := Seq("1.5.0"),
   Compile / sourceGenerators += Def.task {
     val file = (Compile / sourceManaged).value / organization.value.replace(".","/") / "Version.scala"
     val code = {
@@ -26,7 +26,7 @@ object Version {
 
 lazy val baseSettings = Seq(
   organization := "org.scalatra.scalate",
-  version := "1.9.7.0",
+  version := "1.10.0.0-SNAPSHOT",
   Global / transitiveClassifiers := Seq(Artifact.SourceClassifier),
   Test / parallelExecution := false,
   Test / logBuffered := false,

--- a/plugin/src/sbt-test/plugin/always_recompile/build.sbt
+++ b/plugin/src/sbt-test/plugin/always_recompile/build.sbt
@@ -1,9 +1,7 @@
 import org.fusesource.scalate.ScalatePlugin._
 import ScalateKeys._
 
-scalaVersion := "2.12.8"
-
-resolvers += Resolver.file("ivy-local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.mavenStylePatterns)
+scalaVersion := "2.12.20"
 
 libraryDependencies += "org.scalatra.scalate" %% "scalate-core" % "1.10.1" % "compile"
 

--- a/plugin/src/sbt-test/plugin/always_recompile/project/plugins.sbt
+++ b/plugin/src/sbt-test/plugin/always_recompile/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += Resolver.file("ivy-local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.mavenStylePatterns)
-
 {
   val pluginVersion = System.getProperty("plugin.version")
   if (pluginVersion == null) {

--- a/plugin/src/sbt-test/plugin/overwrite/build.sbt
+++ b/plugin/src/sbt-test/plugin/overwrite/build.sbt
@@ -1,9 +1,7 @@
 import org.fusesource.scalate.ScalatePlugin._
 import ScalateKeys._
 
-scalaVersion := "2.12.8"
-
-resolvers += Resolver.file("ivy-local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.mavenStylePatterns)
+scalaVersion := "2.12.20"
 
 libraryDependencies += "org.scalatra.scalate" %% "scalate-core" % "1.10.1" % "compile"
 

--- a/plugin/src/sbt-test/plugin/overwrite/project/plugins.sbt
+++ b/plugin/src/sbt-test/plugin/overwrite/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += Resolver.file("ivy-local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.mavenStylePatterns)
-
 {
   val pluginVersion = System.getProperty("plugin.version")
   if (pluginVersion == null) {

--- a/plugin/src/sbt-test/plugin/simple/build.sbt
+++ b/plugin/src/sbt-test/plugin/simple/build.sbt
@@ -1,9 +1,7 @@
 import org.fusesource.scalate.ScalatePlugin._
 import ScalateKeys._
 
-scalaVersion := "2.12.8"
-
-resolvers += Resolver.file("ivy-local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.mavenStylePatterns)
+scalaVersion := "2.12.20"
 
 libraryDependencies += "org.scalatra.scalate" %% "scalate-core" % "1.10.1" % "compile"
 

--- a/plugin/src/sbt-test/plugin/simple/project/plugins.sbt
+++ b/plugin/src/sbt-test/plugin/simple/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += Resolver.file("ivy-local", file(Path.userHome.absolutePath + "/.ivy2/local"))(Resolver.mavenStylePatterns)
-
 {
   val pluginVersion = System.getProperty("plugin.version")
   if (pluginVersion == null) {

--- a/publish.sh
+++ b/publish.sh
@@ -10,6 +10,9 @@ sbt \
     ++2.13.x \
     clean \
     publishSigned \
+    ++3.3.x \
+    clean \
+    publishSigned \
     "project plugin" \
     clean \
     publishSigned


### PR DESCRIPTION
This pull request enables the use of sbt-scalate-precompiler in Scala 3 projects. The following changes have been made:

- Added Scala version 3.3.3 to cross-build versions.
- Updated the minimum sbt version to 1.5.0 to support Scala 3.
- Fixed as many compilation warnings as possible.
- Updated the Scala version used in scripted tests.

These changes ensure that sbt-scalate-precompiler can be used seamlessly in Scala 3 projects. Please review and merge if everything looks good.